### PR TITLE
Fix log point activation by matching all classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ Start your application with the agent:
 java -javaagent:path/to/jlogpoint.jar=classPattern=com.example.*,methodPattern=get.* -jar yourapp.jar
 ```
 
-Visit `http://localhost:8080/` for the list of HTTP API endpoints that
+The agent instruments all classes and methods by default if no patterns are
+provided. Visit `http://localhost:8081/` for the list of HTTP API endpoints that
 allow managing log points at runtime.


### PR DESCRIPTION
## Summary
- restore default regex patterns in `LogConfig`
- normalize empty patterns to match all classes
- clarify default behaviour and API port in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*