### PR TITLE
Add Codex setup script

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,1 @@
+setup: ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Install Java and Maven
+apt-get update
+apt-get install -y maven openjdk-17-jdk
+
+# Additional setup commands can be added here


### PR DESCRIPTION
## Summary
- add `setup.sh` to install Maven and JDK
- configure Codex to run the setup script via `codex.yaml`

## Testing
- `mvn -q -DskipTests=false package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68336b0a20708322bfa8b0f83f228c32