### PR TITLE
Add unit tests for agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <artifactId>byte-buddy-agent</artifactId>
             <version>1.14.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -55,6 +61,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/LogInjectionAgentTest.java
+++ b/src/test/java/LogInjectionAgentTest.java
@@ -1,0 +1,54 @@
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LogInjectionAgentTest {
+
+    private Instrumentation getInstrumentation() {
+        return ByteBuddyAgent.install();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // Stop the HTTP server and reset static fields
+        Field serverField = LogInjectionAgent.class.getDeclaredField("apiServer");
+        serverField.setAccessible(true);
+        Object server = serverField.get(null);
+        if (server != null) {
+            server.getClass().getMethod("stop").invoke(server);
+        }
+        Field managerField = LogInjectionAgent.class.getDeclaredField("logPointManager");
+        managerField.setAccessible(true);
+        managerField.set(null, null);
+        serverField.set(null, null);
+    }
+
+    @Test
+    public void testPremainInitializesManager() {
+        Instrumentation inst = getInstrumentation();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+        try {
+            LogInjectionAgent.premain("apiPort=0", inst);
+        } finally {
+            System.setOut(original);
+        }
+        assertTrue(out.toString().contains("Starting Log Injection Agent"));
+        assertNotNull(LogInjectionAgent.getLogPointManager());
+    }
+
+    @Test
+    public void testAgentmainDelegatesToPremain() {
+        Instrumentation inst = getInstrumentation();
+        LogInjectionAgent.agentmain("apiPort=0", inst);
+        assertNotNull(LogInjectionAgent.getLogPointManager());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit Jupiter to the POM and configure surefire
- create `LogInjectionAgentTest` to exercise `premain` and `agentmain`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d8021270883229eba248196df08ea