### PR TITLE
Add basic tests for LogInjectionAgent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,24 @@
             <artifactId>byte-buddy-agent</artifactId>
             <version>1.14.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/LogInjectionAgentTest.java
+++ b/src/test/java/LogInjectionAgentTest.java
@@ -1,0 +1,47 @@
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Field;
+
+public class LogInjectionAgentTest {
+
+    @BeforeEach
+    void reset() throws Exception {
+        Field managerField = LogInjectionAgent.class.getDeclaredField("logPointManager");
+        managerField.setAccessible(true);
+        managerField.set(null, null);
+
+        Field serverField = LogInjectionAgent.class.getDeclaredField("apiServer");
+        serverField.setAccessible(true);
+        HttpApiServer server = (HttpApiServer) serverField.get(null);
+        if (server != null) {
+            server.stop();
+        }
+        serverField.set(null, null);
+    }
+
+    @Test
+    void test_GetLogPointManager_BeforeInitialization_ReturnsNull() {
+        Assertions.assertNull(LogInjectionAgent.getLogPointManager());
+    }
+
+    @Test
+    void test_GetLogPointManager_AfterPremain_ReturnsInitializedManager() {
+        Instrumentation inst = Mockito.mock(Instrumentation.class);
+        Mockito.when(inst.isRedefineClassesSupported()).thenReturn(true);
+        Mockito.when(inst.isRetransformClassesSupported()).thenReturn(true);
+
+        LogInjectionAgent.premain("apiPort=0", inst);
+        Assertions.assertNotNull(LogInjectionAgent.getLogPointManager());
+    }
+
+    @Test
+    void test_Agentmain_WithValidArgs_InitializesManager() {
+        Instrumentation inst = Mockito.mock(Instrumentation.class);
+        Mockito.when(inst.isRedefineClassesSupported()).thenReturn(true);
+        Mockito.when(inst.isRetransformClassesSupported()).thenReturn(true);
+
+        LogInjectionAgent.agentmain("apiPort=0", inst);
+        Assertions.assertNotNull(LogInjectionAgent.getLogPointManager());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit and Mockito dependencies
- cover LogInjectionAgent premain/agentmain with unit tests

## Testing
- `mvn -q test` *(fails: Plugin resolution could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_689f60be63fc8322b06b5b49b29f9677